### PR TITLE
feat (config): add DATABASE_HOST and DATABASE_PORT env vars

### DIFF
--- a/docker/docker-compose.debug.yml
+++ b/docker/docker-compose.debug.yml
@@ -41,6 +41,8 @@ services:
       - DATABASE=email_archive_django # must match db:MARIADB_DATABASE
       - DATABASE_USER=user # must match db:MARIADB_USER
       - DATABASE_PASSWORD=passwd # must match db:MARIADB_PASSWORD
+      - DATABASE_HOST=db # set this to your postgres host when DATABASE_TYPE=postgresql
+      - DATABASE_PORT=3306 # set to 5432 for postgres
       - DJANGO_SUPERUSER_PASSWORD=rootqwertz123
       - SECRET_KEY='PLEASE_REPLACE_ME_WITH_THE_OUTPUT_OF_A_STRONG_RANDOM_GENERATOR!'
       - ALLOWED_HOSTS=*

--- a/docker/docker-compose.minimal.yml
+++ b/docker/docker-compose.minimal.yml
@@ -29,6 +29,8 @@ services:
       - DATABASE=email_archive_django # must match db:MARIADB_DATABASE
       - DATABASE_USER=user # must match db:MARIADB_USER
       - DATABASE_PASSWORD=passwd # must match db:MARIADB_PASSWORD
+      - DATABASE_HOST=db # set this to your postgres host when DATABASE_TYPE=postgresql
+      - DATABASE_PORT=3306 # set to 5432 for postgres
       - DJANGO_SUPERUSER_PASSWORD=rootqwertz123
       - SECRET_KEY='PLEASE_REPLACE_ME_WITH_THE_OUTPUT_OF_A_STRONG_RANDOM_GENERATOR!'
       - ALLOWED_HOSTS=localhost,eonvelope.mydomain.tld # all allowed host URLs separated by ,

--- a/docker/docker-compose.slim.yml
+++ b/docker/docker-compose.slim.yml
@@ -29,6 +29,8 @@ services:
       - DATABASE=email_archive_django # must match db:MARIADB_DATABASE
       - DATABASE_USER=user # must match db:MARIADB_USER
       - DATABASE_PASSWORD=passwd # must match db:MARIADB_PASSWORD
+      - DATABASE_HOST=db # set this to your postgres host when DATABASE_TYPE=postgresql
+      - DATABASE_PORT=3306 # set to 5432 for postgres
       - DJANGO_SUPERUSER_PASSWORD=rootqwertz123
       - SECRET_KEY='PLEASE_REPLACE_ME_WITH_THE_OUTPUT_OF_A_STRONG_RANDOM_GENERATOR!'
       - ALLOWED_HOSTS=localhost,eonvelope.mydomain.tld # all allowed host URLs separated by ,

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       - DATABASE=email_archive_django # must match db:MARIADB_DATABASE
       - DATABASE_USER=user # must match db:MARIADB_USER
       - DATABASE_PASSWORD=passwd # must match db:MARIADB_PASSWORD
+      - DATABASE_HOST=db # set this to your postgres host when DATABASE_TYPE=postgresql
+      - DATABASE_PORT=3306 # set to 5432 for postgres
       - DJANGO_SUPERUSER_PASSWORD=rootqwertz123
       - SECRET_KEY='PLEASE_REPLACE_ME_WITH_THE_OUTPUT_OF_A_STRONG_RANDOM_GENERATOR!'
       - ALLOWED_HOSTS=localhost,eonvelope.mydomain.tld # all allowed host URLs separated by ,

--- a/docker/kubernetes/full/web-deployment.yaml
+++ b/docker/kubernetes/full/web-deployment.yaml
@@ -32,6 +32,10 @@ spec:
               value: INFO
             - name: DATABASE
               value: email_archive_django
+            - name: DATABASE_HOST
+              value: db
+            - name: DATABASE_PORT
+              value: "3306"
             - name: DATABASE_PASSWORD
               value: passwd
             - name: DATABASE_USER
@@ -55,7 +59,7 @@ spec:
             - name: REGISTRATION_ENABLED
               value: "False"
             - name: SECRET_KEY
-              value: '''PLEASE_REPLACE_ME_WITH_THE_OUTPUT_OF_A_STRONG_RANDOM_GENERATOR!'''
+              value: "'PLEASE_REPLACE_ME_WITH_THE_OUTPUT_OF_A_STRONG_RANDOM_GENERATOR!'"
             - name: STRICT_PASSWORDS
               value: "True"
           image: eonvelope

--- a/docker/kubernetes/minimal/web-deployment.yaml
+++ b/docker/kubernetes/minimal/web-deployment.yaml
@@ -28,6 +28,10 @@ spec:
               value: localhost,eonvelope.mydomain.tld
             - name: DATABASE
               value: email_archive_django
+            - name: DATABASE_HOST
+              value: db
+            - name: DATABASE_PORT
+              value: "3306"
             - name: DATABASE_PASSWORD
               value: passwd
             - name: DATABASE_USER
@@ -35,7 +39,7 @@ spec:
             - name: DJANGO_SUPERUSER_PASSWORD
               value: rootqwertz123
             - name: SECRET_KEY
-              value: '''PLEASE_REPLACE_ME_WITH_THE_OUTPUT_OF_A_STRONG_RANDOM_GENERATOR!'''
+              value: "'PLEASE_REPLACE_ME_WITH_THE_OUTPUT_OF_A_STRONG_RANDOM_GENERATOR!'"
           image: eonvelope
           name: eonvelope-web
           ports:

--- a/docs/source/rst/configuration.rst
+++ b/docs/source/rst/configuration.rst
@@ -65,6 +65,12 @@ Optional
 |                                   |             | Possible values are mysql, postgresql and sqlite3.                                                                        |
 |                                   |             | Must match the database type of the db container.                                                                         |
 +-----------------------------------+-------------+---------------------------------------------------------------------------------------------------------------------------+
+| DATABASE_HOST                     | *db*        | The hostname of the database server.                                                                                      |
+|                                   |             | Use this to connect to an external database host.                                                                         |
++-----------------------------------+-------------+---------------------------------------------------------------------------------------------------------------------------+
+| DATABASE_PORT                     | *3306/5432* | The port of the database server.                                                                                          |
+|                                   |             | Defaults to 3306 for mysql and 5432 for postgresql.                                                                       |
++-----------------------------------+-------------+---------------------------------------------------------------------------------------------------------------------------+
 | APP_LOG_LEVEL                     | *INFO*      | The log level of the Eonvelope logger.                                                                                    |
 |                                   |             | It logs to Eonvelope.log in the logs docker volume                                                                        |
 |                                   |             | and contains information about events in the Eonvelope application components.                                            |

--- a/docs/source/rst/installation.rst
+++ b/docs/source/rst/installation.rst
@@ -104,8 +104,9 @@ using the `DATABASE_TYPE` environment variable.
 See :doc:`configuration` for more details on this.
 
 .. important::
-    It is crucial that the name of the database service in the stack is *db*!
-    Otherwise the connection from the Eonvelope container to the database will fail.
+   If you keep the default configuration, the database service in the stack should be named *db*.
+   If you use a different service name or an external database, set ``DATABASE_HOST`` and optionally
+   ``DATABASE_PORT`` in the web service environment.
 
 
 External Database

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -118,20 +118,26 @@ if not SLIM:
 ### Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
+DATABASE_TYPE = env("DATABASE_TYPE", default="mysql")
+DATABASE_PORT_DEFAULT = ""
+if DATABASE_TYPE == "mysql":
+    DATABASE_PORT_DEFAULT = "3306"
+elif DATABASE_TYPE == "postgresql":
+    DATABASE_PORT_DEFAULT = "5432"
+
 DATABASES = {
     "default": {
-        "ENGINE": (
-            "django_prometheus.db.backends." + env("DATABASE_TYPE", default="mysql")
-        ),
+        "ENGINE": ("django_prometheus.db.backends." + DATABASE_TYPE),
         "NAME": env("DATABASE", default="email_archive_django"),
         "USER": env("DATABASE_USER", default="user"),
         "PASSWORD": env("DATABASE_PASSWORD", default="passwd"),
-        "HOST": "db",
+        "HOST": env("DATABASE_HOST", default="db"),
+        "PORT": env("DATABASE_PORT", default=DATABASE_PORT_DEFAULT),
         "OPTIONS": (
             {
                 "charset": "utf8mb4",
             }
-            if env("DATABASE_TYPE", default="mysql") == "mysql"
+            if DATABASE_TYPE == "mysql"
             else {}
         ),
     }


### PR DESCRIPTION
## Summary

- Make `DATABASE_HOST` and `DATABASE_PORT` configurable via environment variables (previously `HOST` was hardcoded to `"db"`)
- Extract `DATABASE_TYPE` into a reusable variable to avoid redundant `env()` reads
- Add the new variables to all docker-compose files (full, minimal, slim, debug) and kubernetes manifests
- Document `DATABASE_HOST` and `DATABASE_PORT` in the configuration reference
- Update installation docs to reflect that an external or differently named DB service no longer requires `extra_hosts` workarounds

## Motivation

Users connecting to an external database or using a different docker service name had to rely on the `extra_hosts` workaround. With these env vars, the host and port can be set directly, which is simpler and more intuitive.

## Test plan

- [ ] Verify default behavior is unchanged (`DATABASE_HOST=db`, `DATABASE_PORT=3306` for mysql)
- [ ] Set `DATABASE_HOST` and `DATABASE_PORT` to custom values and confirm the app connects to the correct database
- [ ] Test with `DATABASE_TYPE=postgresql` and verify the default port resolves to `5432`

🤖 Generated with [Claude Code](https://claude.com/claude-code)